### PR TITLE
added cycle inactiveSelections commands

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -466,6 +466,65 @@ const activate = (context: vscode.ExtensionContext) => {
       activeEditorData.inactiveSelections = []
    })
 
+   const cycleInactiveSelections = vscode.commands.registerCommand('kcs.cycleInactiveSelections',() => {
+      const activeEditor = vscode.window.activeTextEditor
+      const activeDocUri = vscode.window.activeTextEditor.document.uri.toString()
+      const activeEditorData = mainData[activeDocUri]
+
+      if (!activeEditorData || !activeEditorData.inactiveSelections.length) {
+         return
+      }
+
+      const inactiveSelections = activeEditorData.inactiveSelections.map(
+         (range) => new vscode.Selection(range.start, range.end)
+      )
+
+      const [currentSelection] = activeEditor.selections
+      let nextSelection = inactiveSelections.pop()
+      let prevSelection;
+
+      while (nextSelection && !currentSelection.isEqual(nextSelection)){
+         prevSelection = nextSelection
+         nextSelection = inactiveSelections.pop()
+      }
+
+      for (const visibleEditor of vscode.window.visibleTextEditors) {
+         if (visibleEditor.document.uri.toString() === activeDocUri) {
+            visibleEditor.selections = [ prevSelection ? prevSelection : inactiveSelections[0] ]
+         }
+      }
+   })
+
+   const reverseCycleInactiveSelections = vscode.commands.registerCommand('kcs.reverseCycleInactiveSelections',() => {
+      const activeEditor = vscode.window.activeTextEditor
+      const activeDocUri = vscode.window.activeTextEditor.document.uri.toString()
+      const activeEditorData = mainData[activeDocUri]
+
+      if (!activeEditorData || !activeEditorData.inactiveSelections.length) {
+         return
+      }
+
+      const inactiveSelections = activeEditorData.inactiveSelections.map(
+         (range) => new vscode.Selection(range.start, range.end)
+      ).reverse()
+
+      const [currentSelection] = activeEditor.selections
+      let nextSelection = inactiveSelections.pop()
+      let prevSelection;
+
+      while (nextSelection && !currentSelection.isEqual(nextSelection)){
+         prevSelection = nextSelection
+         nextSelection = inactiveSelections.pop()
+      }
+
+      for (const visibleEditor of vscode.window.visibleTextEditors) {
+         if (visibleEditor.document.uri.toString() === activeDocUri) {
+            visibleEditor.selections = [ prevSelection ? prevSelection : inactiveSelections[0] ]
+         }
+      }
+   })
+
+
    const removeInactiveSelections = vscode.commands.registerCommand(
       'kcs.removeInactiveSelections',
       () => {
@@ -618,6 +677,8 @@ const activate = (context: vscode.ExtensionContext) => {
    context.subscriptions.push(
       placeInactiveSelection,
       activateSelections,
+      cycleInactiveSelections,
+      reverseCycleInactiveSelections,
       removeInactiveSelections,
       showImportantChangesDisposable,
       undo,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
             "title": "KCS: Remove Inactive Selections"
          },
          {
+            "command": "kcs.cycleInactiveSelections",
+            "title": "KCS: Cycle through Inactive Selections"
+         },
+         {
+            "command": "kcs.reverseCycleInactiveSelections",
+            "title": "KCS: Cycle through Inactive Selections backwards"
+         },
+         {
             "command": "kcs.showImportantChanges",
             "title": "KCS: Show Important Changes"
          },
@@ -60,6 +68,16 @@
          {
             "command": "kcs.activateSelections",
             "key": "pageup",
+            "when": "editorTextFocus"
+         },
+         {
+            "command": "kcs.cycleInactiveSelections",
+            "key": "alt+tab",
+            "when": "editorTextFocus"
+         },
+         {
+            "command": "kcs.reverseCycleInactiveSelections",
+            "key": "shift+alt+tab",
             "when": "editorTextFocus"
          },
          {


### PR DESCRIPTION
This PR adds two new commands for a new Feature.

The ability to jump the cursor through the inactive selections.

#### `kcs.cycleInactiveSelections` 
&&
#### `kcs.reverseCycleInactiveSelections`


Using these commands the active cursor of the document will cycle through the inactive selections allowing you to move quickly from one to the other. Please see the attached video for an example of how this can be used!






personally, I think the keybindings for this extension should be changed:

- **(Alt + Click)** is how you natively add an extra cursor to the document.  
SO:
- **(Alt + Enter)** feels like a VERY intuitive option for adding a cursor with the keyboard and there are no conflicts with this key

Admittedly I tried using **(Enter)** for `"command": "kcs.activateSelection", "when": "inactiveSelections"` and it feels very intuitive, almost a little like a modal editing feature like VIM. but It prevents you from adding new lines while placing cursors so I switched to **(^Enter)** to activate

#### So in keeping with my other choices the key bindings provided in this PR for the new commands are: 

**(alt+tab)**  and **(shift+alt+tab)** to cycle through inactive cursors

These fit well with my theme, but also feel natural and intuitive to use.

I understand if you do not want to change the default keybindings for your commands in this extension, as it is easy enough for the user to change it to their own preferences, I just figured I'd give you my thoughts. 
